### PR TITLE
Fix for ssjs.php on mongodb >= 4.2.

### DIFF
--- a/NoSQL/docker-compose.yml
+++ b/NoSQL/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - "mongodb"
 
     mongodb:
-        image: mongo:latest
+        image: mongo:4.0
          
         restart: always
         ports:


### PR DESCRIPTION
Starting in version 4.2, mongodb removes the eval/execute command (execute is a wrapper for the  eval). So a code $db->execute($q) will not work on latest mongodb docker images.